### PR TITLE
Bump setuptools to resolve Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy~=1.25.2
 matplotlib~=3.7.2
 tqdm~=4.66.1
-setuptools~=58.1.0
+setuptools~=78.1.1
 chipwhisperer~=5.7.0
 cwtvla~=0.1.3
 h5py~=3.9.0


### PR DESCRIPTION
### Motivation
- Address three security advisories for `setuptools` (GHSA-cx63-2mw6-8hw5 / CVE-2024-6345, GHSA-r9hx-vwmv-q579 / CVE-2022-40897, GHSA-5rjg-fvgr-3xxf / CVE-2025-47273) by upgrading to a patched release.

### Description
- Updated `requirements.txt` to replace `setuptools~=58.1.0` with `setuptools~=78.1.1` and made no changes to artifact or scientific code (only the dependency entry was modified). The changed file is `requirements.txt`.

### Testing
- Performed a syntax/compile check by compiling all `.py` files with `py_compile` (passed; pre-existing `SyntaxWarning`s noted in `WPI_SCA_LIBRARY/FileFormat.py` and `WPI_SCA_LIBRARY_v0/FileFormat.py`), ran `python -m pip check` (no broken requirements), and attempted `python -m pip install --dry-run -r requirements.txt` and `python -m pip install --dry-run 'setuptools~=78.1.1'` which were blocked by the environment package-index proxy returning `403 Forbidden`, and `python setup.py --name` could not be exercised because `setuptools` is not installed in the runtime; all automated checks that could run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a287a86e4f48330af29c184196a34f4)